### PR TITLE
RedirectIfAuthenticated middleware API support

### DIFF
--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -21,6 +21,9 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
+                if ($request->expectsJson()) {
+                    return response()->json(['message' => 'Already authenticated.']);
+                }
                 return redirect(RouteServiceProvider::HOME);
             }
         }


### PR DESCRIPTION
RedirectIfAuthenticated middleware not work correctly in the context of a Laravel Breeze application scaffolded with api option (php artisan breeze:install api) or in general in the context of a client-driven authentication where Laravel act as a pure Backend.

See this issue for more explanations: https://github.com/platformsh-templates/laravel/issues/50